### PR TITLE
Fix PHP Parse error

### DIFF
--- a/tests/functional/WebsiteParserTest.php
+++ b/tests/functional/WebsiteParserTest.php
@@ -35,9 +35,7 @@ class WebsiteParserTest extends SapphireTest {
 }
 
 class TestFetcher implements IFetcher, TestOnly {
-
-    private static $data = [
-        "http://normal.site" => <<<EOT
+    const HTML_DOC = <<<'EOT'
 <!doctype html>
 <html lang="en">
 <head>
@@ -49,8 +47,10 @@ class TestFetcher implements IFetcher, TestOnly {
 
 </body>
 </html>
-EOT
-        ,
+EOT;
+
+    private static $data = [
+        "http://normal.site" => TestFetcher::HTML_DOC,
     ];
 
     public function fetch($url) {


### PR DESCRIPTION
Error:
```php
PHP Parse error:  syntax error, unexpected end of file, expecting heredoc end (T_END_HEREDOC) in /framework/core/manifest/ConfigStaticManifest.php(372) : eval()'d code on line 15
```
Heredoc does not work well in an array. Moved to nowdoc which is cleaner for static and constant values and put it into a constant to keep it readable.